### PR TITLE
feat(frontend): implement search form with Material datepickers and results table wired to /api/search

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@angular/animations": "^20.2.4",
         "@angular/cdk": "^20.2.2",
         "@angular/common": "^20.1.0",
         "@angular/compiler": "^20.1.0",
@@ -318,6 +319,21 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
         "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
         "yarn": ">= 1.13.0"
+      }
+    },
+    "node_modules/@angular/animations": {
+      "version": "20.2.4",
+      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-20.2.4.tgz",
+      "integrity": "sha512-mXiTlXZgAF4uYonOt7l2w7uvLLTJEk6jqs3H291bYuoDRM8R166UjN7ygAeBmPiJ4TLMyKGkwMQy3b1Vvw4RQA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@angular/core": "20.2.4"
       }
     },
     "node_modules/@angular/build": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
   },
   "private": true,
   "dependencies": {
+    "@angular/animations": "^20.2.4",
     "@angular/cdk": "^20.2.2",
     "@angular/common": "^20.1.0",
     "@angular/compiler": "^20.1.0",

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,0 +1,10 @@
+import { Component } from "@angular/core";
+import { RouterOutlet } from "@angular/router";
+
+@Component({
+  selector: "app-root",
+  standalone: true,
+  imports: [RouterOutlet],
+  template: `<router-outlet></router-outlet>`,
+})
+export class AppComponent {}

--- a/frontend/src/app/app.config.ts
+++ b/frontend/src/app/app.config.ts
@@ -2,17 +2,22 @@ import {
   ApplicationConfig,
   provideBrowserGlobalErrorListeners,
   provideZoneChangeDetection,
-} from '@angular/core';
-import { provideRouter } from '@angular/router';
-
-import { routes } from './app.routes';
-import { provideAnimations } from '@angular/platform-browser/animations';
+} from "@angular/core";
+import { provideRouter } from "@angular/router";
+import { provideAnimations } from "@angular/platform-browser/animations";
+import { provideHttpClient } from "@angular/common/http";
+import { routes } from "./app.routes";
+import { LOCALE_ID } from "@angular/core";
+import { MAT_DATE_LOCALE } from "@angular/material/core";
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideAnimations(),
+    provideHttpClient(),
     provideRouter(routes),
+    { provide: LOCALE_ID, useValue: "es" },
+    { provide: MAT_DATE_LOCALE, useValue: "es-ES" },
   ],
 };

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -1,3 +1,7 @@
-import { Routes } from '@angular/router';
+import { Routes } from "@angular/router";
+import { SearchComponent } from "./features/search/search"; // <- sin .component
 
-export const routes: Routes = [];
+export const routes: Routes = [
+  { path: "", pathMatch: "full", redirectTo: "search" },
+  { path: "search", component: SearchComponent },
+];

--- a/frontend/src/app/core/api.service.ts
+++ b/frontend/src/app/core/api.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from "@angular/core";
+import { HttpClient, HttpParams } from "@angular/common/http";
+import { Observable } from "rxjs";
+
+export interface SearchResult {
+  roomId: number;
+  type: string;
+  capacity: number;
+  price: number;
+}
+export interface SearchResponse {
+  checkIn: string;
+  checkOut: string;
+  guests: number;
+  results: SearchResult[];
+}
+
+@Injectable({ providedIn: "root" })
+export class ApiService {
+  constructor(private http: HttpClient) {}
+  health() {
+    return this.http.get<{ status: string }>("/api/health");
+  }
+  search(
+    checkIn: string,
+    checkOut: string,
+    guests: number
+  ): Observable<SearchResponse> {
+    const params = new HttpParams()
+      .set("checkIn", checkIn)
+      .set("checkOut", checkOut)
+      .set("guests", guests.toString());
+    return this.http.get<SearchResponse>("/api/search", { params });
+  }
+}

--- a/frontend/src/app/features/search/search.html
+++ b/frontend/src/app/features/search/search.html
@@ -1,0 +1,78 @@
+<mat-card>
+  <h2>Buscar habitaciones</h2>
+
+  <form (ngSubmit)="submit()" [formGroup]="form" class="form-grid">
+    <mat-form-field appearance="outline">
+      <mat-label>Check-in</mat-label>
+      <input
+        matInput
+        [matDatepicker]="pickerIn"
+        formControlName="checkIn"
+        required
+      />
+      <mat-datepicker-toggle matSuffix [for]="pickerIn"></mat-datepicker-toggle>
+      <mat-datepicker #pickerIn></mat-datepicker>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline">
+      <mat-label>Check-out</mat-label>
+      <input
+        matInput
+        [matDatepicker]="pickerOut"
+        formControlName="checkOut"
+        required
+      />
+      <mat-datepicker-toggle
+        matSuffix
+        [for]="pickerOut"
+      ></mat-datepicker-toggle>
+      <mat-datepicker #pickerOut></mat-datepicker>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline">
+      <mat-label>Huéspedes</mat-label>
+      <input matInput type="number" min="1" formControlName="guests" required />
+    </mat-form-field>
+
+    <button
+      mat-raised-button
+      color="primary"
+      type="submit"
+      [disabled]="form.invalid || loading()"
+    >
+      {{ loading() ? "Buscando..." : "Buscar" }}
+    </button>
+  </form>
+
+  <p *ngIf="error()" style="color: var(--mat-sys-error)">⚠ {{ error() }}</p>
+</mat-card>
+
+<mat-card *ngIf="data()">
+  <h3>Resultados</h3>
+  <table
+    mat-table
+    [dataSource]="data()!.results"
+    class="mat-elevation-z1"
+    style="width: 100%"
+  >
+    <ng-container matColumnDef="roomId">
+      <th mat-header-cell *matHeaderCellDef>ID</th>
+      <td mat-cell *matCellDef="let r">{{ r.roomId }}</td>
+    </ng-container>
+    <ng-container matColumnDef="type">
+      <th mat-header-cell *matHeaderCellDef>Tipo</th>
+      <td mat-cell *matCellDef="let r">{{ r.type }}</td>
+    </ng-container>
+    <ng-container matColumnDef="capacity">
+      <th mat-header-cell *matHeaderCellDef>Capacidad</th>
+      <td mat-cell *matCellDef="let r">{{ r.capacity }}</td>
+    </ng-container>
+    <ng-container matColumnDef="price">
+      <th mat-header-cell *matHeaderCellDef>Precio</th>
+      <td mat-cell *matCellDef="let r">{{ r.price | currency : "USD" }}</td>
+    </ng-container>
+
+    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+    <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+  </table>
+</mat-card>

--- a/frontend/src/app/features/search/search.scss
+++ b/frontend/src/app/features/search/search.scss
@@ -1,0 +1,16 @@
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(180px, 1fr));
+  gap: 12px;
+  align-items: end;
+
+  @media (max-width: 900px) {
+    grid-template-columns: 1fr 1fr;
+  }
+  @media (max-width: 600px) {
+    grid-template-columns: 1fr;
+  }
+}
+mat-card {
+  margin-block: 12px;
+}

--- a/frontend/src/app/features/search/search.spec.ts
+++ b/frontend/src/app/features/search/search.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { Search } from './search';
+
+describe('Search', () => {
+  let component: Search;
+  let fixture: ComponentFixture<Search>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [Search]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(Search);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/src/app/features/search/search.ts
+++ b/frontend/src/app/features/search/search.ts
@@ -1,0 +1,96 @@
+import { Component, signal } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import {
+  FormControl,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators,
+} from "@angular/forms";
+import { MatFormFieldModule } from "@angular/material/form-field";
+import { MatInputModule } from "@angular/material/input";
+import { MatDatepickerModule } from "@angular/material/datepicker";
+import { MatNativeDateModule } from "@angular/material/core";
+import { MatButtonModule } from "@angular/material/button";
+import { MatCardModule } from "@angular/material/card";
+import { MatTableModule } from "@angular/material/table";
+import { ApiService, SearchResponse } from "../../core/api.service";
+
+@Component({
+  selector: "app-search",
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatDatepickerModule,
+    MatNativeDateModule,
+    MatButtonModule,
+    MatCardModule,
+    MatTableModule,
+  ],
+  templateUrl: "./search.html",
+  styleUrls: ["./search.scss"],
+})
+export class SearchComponent {
+  form = new FormGroup({
+    checkIn: new FormControl<Date | null>(null, {
+      validators: [Validators.required],
+    }),
+    checkOut: new FormControl<Date | null>(null, {
+      validators: [Validators.required],
+    }),
+    guests: new FormControl<number>(1, {
+      nonNullable: true,
+      validators: [Validators.required, Validators.min(1)],
+    }),
+  });
+
+  loading = signal(false);
+  error = signal<string | null>(null);
+  data = signal<SearchResponse | null>(null);
+
+  displayedColumns = ["roomId", "type", "capacity", "price"];
+
+  constructor(private api: ApiService) {}
+
+  private toIsoDateOnly(d: Date): string {
+    const y = d.getFullYear();
+    const m = String(d.getMonth() + 1).padStart(2, "0");
+    const day = String(d.getDate()).padStart(2, "0");
+    return `${y}-${m}-${day}`;
+  }
+
+  submit() {
+    this.error.set(null);
+    this.data.set(null);
+
+    const { checkIn, checkOut, guests } = this.form.value;
+    if (!checkIn || !checkOut || !guests || guests < 1) {
+      this.error.set("Completa fechas válidas y cantidad de huéspedes.");
+      return;
+    }
+    if (checkOut <= checkIn) {
+      this.error.set(
+        "La fecha de salida debe ser posterior a la fecha de entrada."
+      );
+      return;
+    }
+
+    this.loading.set(true);
+    const inStr = this.toIsoDateOnly(checkIn);
+    const outStr = this.toIsoDateOnly(checkOut);
+
+    this.api.search(inStr, outStr, guests).subscribe({
+      next: (resp: SearchResponse) => {
+        // <-- tipo explícito
+        this.data.set(resp);
+        this.loading.set(false);
+      },
+      error: (_e: unknown) => {
+        this.error.set("No se pudo buscar disponibilidad.");
+        this.loading.set(false);
+      },
+    });
+  }
+}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,6 +1,10 @@
-import { bootstrapApplication } from '@angular/platform-browser';
-import { appConfig } from './app/app.config';
-import { App } from './app/app';
+import { bootstrapApplication } from "@angular/platform-browser";
+import { AppComponent } from "./app/app.component";
+import { appConfig } from "./app/app.config";
+import { registerLocaleData } from "@angular/common";
+import localeEs from "@angular/common/locales/es";
+registerLocaleData(localeEs);
 
-bootstrapApplication(App, appConfig)
-  .catch((err) => console.error(err));
+bootstrapApplication(AppComponent, appConfig).catch((err) =>
+  console.error(err)
+);


### PR DESCRIPTION
### 📄 Summary  
This PR introduces a search form in the frontend that connects to the `/api/search` endpoint and displays results in a table format.

---

### 🔧 Changes Included  
- ➕ Created a search form with the following inputs:
  - `Check-in` and `Check-out` dates using Material UI datepickers
  - `Guests` input (e.g., number field or dropdown)
- 📤 Sends query parameters to `/api/search`
- 📥 Displays the response in a table with mock room data
- 🎨 Basic styling using Material UI components

---

### 🧪 Validation & UX  
- Prevents search submission unless all fields are valid
- Validates that:
  - `Check-out` is after `Check-in`
  - `Guests` is at least 1
- Displays error messages or highlights invalid fields

---

### 📘 Notes  
- This is an initial implementation — further enhancements (e.g., loading states, error handling, pagination) will be added in upcoming PRs.
- Data is currently mock-based, depending on the backend’s mock response from `/api/search`.

---

Let me know if you want this description in Spanish or as a reusable PR template too.