### PR TITLE
docs(backend): add OpenAPI examples for GET /api/search

### DIFF
--- a/backend/src/main/java/com/juanda/backend/web/SearchController.java
+++ b/backend/src/main/java/com/juanda/backend/web/SearchController.java
@@ -2,6 +2,10 @@ package com.juanda.backend.web;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,19 +26,55 @@ public class SearchController {
         summary = "Buscar disponibilidad (mock)",
         description = "Devuelve resultados de ejemplo para el rango de fechas y número de huéspedes."
     )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "Resultados encontrados",
+            content = @Content(mediaType = "application/json", examples = @ExampleObject(
+                name = "OK",
+                value = """
+              {
+                "checkIn": "2025-09-15",
+                "checkOut": "2025-09-18",
+                "guests": 2,
+                "results": [
+                  {"roomId":101,"type":"double","capacity":2,"price":120.0},
+                  {"roomId":203,"type":"suite","capacity":3,"price":240.0}
+                ]
+              }
+              """
+            ))
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "Parámetros inválidos",
+            content = @Content(mediaType = "application/json", examples = @ExampleObject(
+                name = "Bad Request",
+                value = """
+              {
+                "timestamp": "2025-09-10T05:10:00Z",
+                "status": 400,
+                "error": "Bad Request",
+                "message": "checkOut debe ser posterior a checkIn y guests >= 1",
+                "path": "/api/search"
+              }
+              """
+            ))
+        )
+    })
     public ResponseEntity<Map<String, Object>> search(
         @RequestParam
         @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
-        @Parameter(description = "Fecha de check-in (YYYY-MM-DD)")
+        @Parameter(description = "Fecha de check-in (YYYY-MM-DD)", example = "2025-09-15")
         LocalDate checkIn,
 
         @RequestParam
         @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
-        @Parameter(description = "Fecha de check-out (YYYY-MM-DD)")
+        @Parameter(description = "Fecha de check-out (YYYY-MM-DD)", example = "2025-09-18")
         LocalDate checkOut,
 
         @RequestParam
-        @Parameter(description = "Número de huéspedes (>= 1)")
+        @Parameter(description = "Número de huéspedes (>= 1)", example = "2")
         int guests
     ) {
         // Validaciones simples (por ahora)


### PR DESCRIPTION
### 📄 Summary  
This PR adds example responses and parameter values to the OpenAPI documentation for the `GET /api/search` endpoint.

---

### 🔧 Changes Included  
- 📝 Added OpenAPI `examples` for:
  - Query parameters: `checkIn`, `checkOut`, and `guests`
  - Successful response (200 OK) with sample room data
- 🧪 Verified that examples are displayed correctly in Swagger UI

---

### 💡 Motivation  
These examples improve the API documentation and help frontend developers and API consumers understand how to interact with the `/api/search` endpoint.

---

### 📘 Notes  
- No functional or behavioral changes were made to the API itself.
- Examples are based on the current mock implementation; they may be updated once the real logic is implemented.