### PR TITLE
feat(backend): Flyway V2__seed with demo users, rooms and 30-day inventory

### DIFF
--- a/backend/src/main/resources/db/migration/V2__seed.sql
+++ b/backend/src/main/resources/db/migration/V2__seed.sql
@@ -1,0 +1,82 @@
+-- =====================================================================
+-- V2__seed.sql  |  Datos de ejemplo para desarrollo
+-- - Usuarios demo
+-- - Habitaciones y plan de tarifas
+-- - Inventario por 30 días, con recargo fin de semana y algunos bloqueos
+-- =====================================================================
+
+-- Usuarios demo (hash ficticio por ahora; auth vendrá luego)
+INSERT INTO app_user (name, email, password_hash, role, created_at)
+SELECT 'Admin', 'admin@example.com', '$2a$10$dummyhashdummyhashdummyhashdummyhashdummyhashdummyh', 'ADMIN', NOW()
+WHERE NOT EXISTS (SELECT 1 FROM app_user WHERE email = 'admin@example.com');
+
+INSERT INTO app_user (name, email, password_hash, role, created_at)
+SELECT 'Juan', 'juan@example.com', '$2a$10$dummyhashdummyhashdummyhashdummyhashdummyhashdummyh', 'USER', NOW()
+WHERE NOT EXISTS (SELECT 1 FROM app_user WHERE email = 'juan@example.com');
+
+-- Planes de tarifa (uno básico)
+INSERT INTO rate_plan (name, currency, tax_percent, cancellation_policy)
+SELECT 'Standard', 'USD', 12.00, 'Cancelación gratuita hasta 24h antes'
+WHERE NOT EXISTS (SELECT 1 FROM rate_plan WHERE name = 'Standard');
+
+-- Habitaciones (códigos únicos)
+INSERT INTO room (code, type, capacity, amenities, status)
+SELECT 'R101', 'single', 1, '{"wifi":true,"ac":true,"tv":true}'::jsonb, 'ACTIVE'
+WHERE NOT EXISTS (SELECT 1 FROM room WHERE code = 'R101');
+
+INSERT INTO room (code, type, capacity, amenities, status)
+SELECT 'R102', 'double', 2, '{"wifi":true,"ac":true,"tv":true}'::jsonb, 'ACTIVE'
+WHERE NOT EXISTS (SELECT 1 FROM room WHERE code = 'R102');
+
+INSERT INTO room (code, type, capacity, amenities, status)
+SELECT 'R201', 'double', 2, '{"wifi":true,"ac":true,"tv":true,"minibar":true}'::jsonb, 'ACTIVE'
+WHERE NOT EXISTS (SELECT 1 FROM room WHERE code = 'R201');
+
+INSERT INTO room (code, type, capacity, amenities, status)
+SELECT 'R202', 'triple', 3, '{"wifi":true,"ac":true,"tv":true,"balcony":true}'::jsonb, 'ACTIVE'
+WHERE NOT EXISTS (SELECT 1 FROM room WHERE code = 'R202');
+
+INSERT INTO room (code, type, capacity, amenities, status)
+SELECT 'S301', 'suite', 3, '{"wifi":true,"ac":true,"tv":true,"minibar":true,"balcony":true}'::jsonb, 'ACTIVE'
+WHERE NOT EXISTS (SELECT 1 FROM room WHERE code = 'S301');
+
+-- Inventario por 30 días (hoy -> hoy+29)
+-- Precios base según tipo + 15% fines de semana (viernes/sábado)
+WITH days AS (
+  SELECT (CURRENT_DATE + offs) AS d
+  FROM generate_series(0, 29) AS offs
+)
+INSERT INTO room_inventory (room_id, date, base_price, is_blocked)
+SELECT r.id,
+       d.d::date,
+       ROUND((
+         CASE r.type
+           WHEN 'single' THEN 80
+           WHEN 'double' THEN 120
+           WHEN 'triple' THEN 150
+           WHEN 'suite'  THEN 220
+           ELSE 100
+         END
+         *
+         CASE WHEN EXTRACT(DOW FROM d.d) IN (5, 6) THEN 1.15 ELSE 1.00 END
+       )::numeric, 2) AS base_price,
+       FALSE
+FROM room r
+CROSS JOIN days d
+-- evita duplicar si ya existiera algún inventario
+WHERE NOT EXISTS (
+  SELECT 1 FROM room_inventory ri
+  WHERE ri.room_id = r.id AND ri.date = d.d::date
+);
+
+-- Bloqueos deterministas (para probar "no disponible")
+-- Bloquea cada 7mo día a la R101 y dos fechas concretas a R201
+UPDATE room_inventory ri
+SET is_blocked = TRUE
+WHERE ri.room_id = (SELECT id FROM room WHERE code = 'R101')
+  AND (EXTRACT(DAY FROM ri.date)::int % 7) = 0;
+
+UPDATE room_inventory ri
+SET is_blocked = TRUE
+WHERE ri.room_id = (SELECT id FROM room WHERE code = 'R201')
+  AND ri.date IN (CURRENT_DATE + 3, CURRENT_DATE + 10);


### PR DESCRIPTION
### ✅ Summary

This pull request adds a new Flyway migration (`V2__seed.sql`) that seeds the database with initial demo data, including users, rooms, and a 30-day inventory. This is intended to support development, testing, and demo environments.

---

### 🛠️ Changes Made

- **Flyway Migration (`V2__seed.sql`)**
  - Inserted demo **users** with basic credentials and roles.
  - Added sample **rooms** for availability and booking simulation.
  - Seeded **inventory data** for the next 30 days to enable testing of availability and reservation logic.

---

### 📎 Notes

- This seed data is intended for **non-production environments** only.
- Ensure Flyway is properly configured to pick up the migration on application startup.
- If you're running the app locally, the data will be available automatically after migration.

---

### 📦 How to Test

1. Run the application with Flyway enabled (`spring.flyway.enabled=true`).
2. Check the database to verify the following tables are populated:
   - `users`
   - `rooms`
   - `inventory`
3. You can log in using seeded credentials (if applicable).

---

### 🔗 Related Issues / Tickets

_No related issues linked._  
_Add references like `Closes #456` here if applicable._