### PR TITLE
Extend search results to include room code and amenities using native query and MapStruct mapping

### DIFF
--- a/backend/src/main/java/com/juanda/backend/repository/RoomInventoryRepository.java
+++ b/backend/src/main/java/com/juanda/backend/repository/RoomInventoryRepository.java
@@ -12,9 +12,11 @@ import java.util.List;
 public interface RoomInventoryRepository extends JpaRepository<RoomInventory, Long> {
 
     @Query(value = """
-        SELECT r.id AS room_id,
+        SELECT r.id   AS room_id,
+               r.code AS code,
                r.type AS type,
                r.capacity AS capacity,
+               r.amenities::text AS amenities_json,
                SUM(ri.base_price) AS total_price
         FROM room r
         JOIN room_inventory ri ON ri.room_id = r.id
@@ -22,7 +24,7 @@ public interface RoomInventoryRepository extends JpaRepository<RoomInventory, Lo
           AND ri.date >= :checkIn
           AND ri.date < :checkOut
           AND ri.is_blocked = FALSE
-        GROUP BY r.id, r.type, r.capacity
+        GROUP BY r.id, r.code, r.type, r.capacity, r.amenities
         HAVING COUNT(ri.id) = :nights
         ORDER BY total_price ASC
         """, nativeQuery = true)

--- a/backend/src/main/java/com/juanda/backend/repository/projection/RoomAvailabilityProjection.java
+++ b/backend/src/main/java/com/juanda/backend/repository/projection/RoomAvailabilityProjection.java
@@ -5,8 +5,10 @@ import java.math.BigDecimal;
 public interface RoomAvailabilityProjection {
 
     Long getRoomId();
+    String getCode();
     String getType();
     Integer getCapacity();
     BigDecimal getTotalPrice();
+    String getAmenitiesJson();
 
 }

--- a/backend/src/main/java/com/juanda/backend/web/dto/SearchResultDTO.java
+++ b/backend/src/main/java/com/juanda/backend/web/dto/SearchResultDTO.java
@@ -1,11 +1,14 @@
 package com.juanda.backend.web.dto;
 
 import java.math.BigDecimal;
+import java.util.Map;
 
 public record SearchResultDTO(
     Long roomId,
+    String code,
     String type,
     Integer capacity,
-    BigDecimal price
+    BigDecimal price,
+    Map<String, Object> amenities
 ) {
 }

--- a/backend/src/main/java/com/juanda/backend/web/mapper/AvailabilityMapper.java
+++ b/backend/src/main/java/com/juanda/backend/web/mapper/AvailabilityMapper.java
@@ -1,18 +1,36 @@
 package com.juanda.backend.web.mapper;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.juanda.backend.repository.projection.RoomAvailabilityProjection;
 import com.juanda.backend.web.dto.SearchResultDTO;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
 import java.util.List;
+import java.util.Map;
 
 @Mapper(componentModel = "spring")
 public interface AvailabilityMapper {
 
     @Mapping(target = "price", source = "totalPrice")
+    @Mapping(target = "amenities", expression = "java(parseAmenities(p.getAmenitiesJson()))")
     SearchResultDTO toDto(RoomAvailabilityProjection p);
 
     List<SearchResultDTO> toDtoList(List<RoomAvailabilityProjection> list);
+
+    // Reutilizable ObjectMapper (Jackson recomienda reutilizarlo, es thread-safe)
+    ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    // Helper para parsear JSON -> Map usando Jackson
+    default Map<String, Object> parseAmenities(String json) {
+        if (json == null || json.isBlank()) return Map.of();
+        try {
+            return OBJECT_MAPPER.readValue(json, new TypeReference<>() {
+            });
+        } catch (Exception e) {
+            return Map.of(); // En caso de JSON inválido
+        }
+    }
 
 }

--- a/backend/src/test/java/com/juanda/backend/service/SearchServiceIT.java
+++ b/backend/src/test/java/com/juanda/backend/service/SearchServiceIT.java
@@ -30,6 +30,13 @@ class SearchServiceIT extends PostgresTC {
             .isSortedAccordingTo((a, b) -> a.price().compareTo(b.price()));
         Assertions.assertThat(resp.results())
             .allSatisfy(r -> Assertions.assertThat(r.price()).isPositive());
+        Assertions.assertThat(resp.results())
+            .allSatisfy(r -> {
+                Assertions.assertThat(r.code()).isNotBlank();
+                Assertions.assertThat(r.amenities()).isNotNull();
+                // Por el seed, la mayoría traen "wifi": true
+                Assertions.assertThat(r.amenities()).containsKey("wifi");
+            });
     }
 
     @Test


### PR DESCRIPTION
📝 Description:

This pull request enhances the backend search results by including additional room details: the room code and a list of amenities. These fields are fetched via a native SQL query and seamlessly mapped using MapStruct.

✅ Main changes:
- Updated database projection to include:
  - `code` (room identifier)
  - `amenities_json` (stored as JSON in the DB)

- Modified SearchResultDTO to expose:
  - `code`: String
  - `amenities`: Map<String, Object> (parsed from JSON)

- MapStruct:
  - Introduced a custom helper to map `amenities_json` (String) into a `Map`.

- Tests:
  - Verified that search results include both `code` and `amenities` fields as expected.

🧩 Why it matters:
These additions make the search results more informative and API-ready by exposing key room attributes. Using native SQL and MapStruct ensures performance and clean data transformation.