### PR TITLE
feat/backend: Redis cache integration :zap:

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -60,6 +60,14 @@
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-cache</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-redis</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.flywaydb</groupId>
       <artifactId>flyway-core</artifactId>
     </dependency>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -75,7 +75,11 @@
       <groupId>org.flywaydb</groupId>
       <artifactId>flyway-database-postgresql</artifactId>
     </dependency>
-
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>redis</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>

--- a/backend/src/main/java/com/juanda/backend/config/CacheConfig.java
+++ b/backend/src/main/java/com/juanda/backend/config/CacheConfig.java
@@ -1,0 +1,45 @@
+package com.juanda.backend.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+
+import java.time.Duration;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+        // ObjectMapper para fechas (LocalDate) y decimales
+        ObjectMapper om = new ObjectMapper();
+        om.registerModule(new JavaTimeModule());
+
+        var serializer = new GenericJackson2JsonRedisSerializer(om);
+
+        // TTL por defecto y formato de clave/valor
+        RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
+            .entryTtl(Duration.ofSeconds(60))  // TTL global 60s
+            .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(serializer))
+            .disableCachingNullValues()
+            .computePrefixWith(cacheName -> "hotel::" + cacheName + "::");
+
+        // Puedes personalizar TTL por caché si quieres:
+        // Map<String, RedisCacheConfiguration> configs = new HashMap<>();
+        // configs.put("search", defaultConfig.entryTtl(Duration.ofSeconds(60)));
+
+        return RedisCacheManager.builder(connectionFactory)
+            .cacheDefaults(defaultConfig)
+            // .withInitialCacheConfigurations(configs)
+            .build();
+    }
+
+}

--- a/backend/src/main/java/com/juanda/backend/service/SearchService.java
+++ b/backend/src/main/java/com/juanda/backend/service/SearchService.java
@@ -5,6 +5,7 @@ import com.juanda.backend.web.dto.SearchResponseDTO;
 import com.juanda.backend.web.error.ApiValidationException;
 import com.juanda.backend.web.mapper.AvailabilityMapper;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
@@ -17,6 +18,10 @@ public class SearchService {
     private final RoomInventoryRepository inventoryRepo;
     private final AvailabilityMapper mapper;
 
+    @Cacheable(
+        value = "search",
+        key = "T(java.lang.String).format('%s|%s|%s', #checkIn, #checkOut, #guests)"
+    )
     public SearchResponseDTO search(LocalDate checkIn, LocalDate checkOut, int guests) {
 
         if (checkIn == null || checkOut == null || !checkOut.isAfter(checkIn) || guests < 1) {

--- a/backend/src/main/resources/application-test.yml
+++ b/backend/src/main/resources/application-test.yml
@@ -1,0 +1,3 @@
+spring:
+  cache:
+    type: none

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -6,9 +6,11 @@ spring:
     url: jdbc:postgresql://localhost:5432/hotel
     username: dev
     password: dev
+    driver-class-name: org.postgresql.Driver
   jpa:
     hibernate:
       ddl-auto: validate
+    open-in-view: false
     properties:
       hibernate:
         format_sql: true
@@ -18,6 +20,14 @@ spring:
 logging:
   level:
     org.springframework: INFO
+
+data:
+  redis:
+    host: localhost
+    port: 6379
+
+  cache:
+    type: redis
 
 app:
   cors:

--- a/backend/src/test/java/com/juanda/backend/service/SearchServiceCacheIT.java
+++ b/backend/src/test/java/com/juanda/backend/service/SearchServiceCacheIT.java
@@ -1,0 +1,54 @@
+package com.juanda.backend.service;
+
+import com.juanda.backend.testinfra.PostgresTC;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class SearchServiceCacheIT extends PostgresTC {
+
+    static GenericContainer<?> REDIS =
+        new GenericContainer<>("redis:7-alpine").withExposedPorts(6379);
+
+    @BeforeAll
+    static void startRedis() { REDIS.start(); }
+
+    @DynamicPropertySource
+    static void props(DynamicPropertyRegistry r) {
+        r.add("spring.data.redis.host", () -> REDIS.getHost());
+        r.add("spring.data.redis.port", () -> REDIS.getFirstMappedPort());
+    }
+
+    @Autowired
+    SearchService service;
+
+    @Autowired
+    StringRedisTemplate redis;
+
+    @Test
+    void second_call_should_hit_cache() {
+        LocalDate ci = LocalDate.now().plusDays(5);
+        LocalDate co = ci.plusDays(2);
+
+        var resp1 = service.search(ci, co, 2);
+        assertThat(resp1.results()).isNotEmpty();
+
+        var beforeKeys = redis.keys("hotel::search::*");
+        var resp2 = service.search(ci, co, 2);
+        var afterKeys  = redis.keys("hotel::search::*");
+
+        assertThat(resp2.results()).isNotEmpty();
+        // Debería haber al menos una clave de cache creada
+        assertThat(afterKeys.size()).isGreaterThanOrEqualTo(beforeKeys == null ? 0 : beforeKeys.size());
+    }
+}


### PR DESCRIPTION
PR Description:

This PR introduces Redis caching for the backend, along with the necessary configurations and optimizations to improve performance in the application.

Changes made:

- feat(backend): Added Spring Cache and Redis starters to the project for caching functionality. :star2:
- chore(backend): Configured Redis host/port for the development environment and disabled caching in tests to ensure proper testing behavior. :wrench:
- feat(backend): Configured RedisCacheManager with JSON serializer and set a 60-second TTL (Time-To-Live) for cache entries. :clock1:
- feat(backend): Implemented caching for the /api/search endpoint based on query parameters: (checkIn|checkOut|guests). :mag_right:
- test(backend): Created integration tests for Redis cache using Testcontainers to ensure proper caching behavior in the development environment. :test_tube:

Motivation :bulb:

This change significantly improves the backend's performance by introducing caching via Redis, reducing the load on the database and enhancing the speed of frequently accessed data, especially for search queries.

Notes :memo:

- The cache has been configured to expire after 60 seconds (TTL), ensuring that the data is kept fresh.
- Redis caching has been disabled during tests to prevent side effects and ensure consistent test results.