### PR TITLE
fix(config): move data.redis and cache under spring. in application.yml* :bug:

### DIFF
--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -7,6 +7,7 @@ spring:
     username: dev
     password: dev
     driver-class-name: org.postgresql.Driver
+
   jpa:
     hibernate:
       ddl-auto: validate
@@ -14,20 +15,21 @@ spring:
     properties:
       hibernate:
         format_sql: true
+
   flyway:
     enabled: true
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+  cache:
+    type: redis
 
 logging:
   level:
     org.springframework: INFO
-
-data:
-  redis:
-    host: localhost
-    port: 6379
-
-  cache:
-    type: redis
 
 app:
   cors:


### PR DESCRIPTION
PR Description:

This PR fixes a configuration issue in the application.yml file where the data.redis and cache properties were defined outside of the spring namespace.

Problem :warning:

Spring Boot requires properties such as data.redis and cache to be nested under the spring: root key in application.yml. When placed outside, these settings are not recognized or applied correctly by the framework.

Fix Applied :hammer:

- Moved the data.redis and cache configuration sections under the spring: key in application.yml to ensure Spring Boot correctly picks them up. ✅

Impact :rocket:

- Ensures Redis and caching configurations are correctly loaded and applied by Spring Boot.
- Prevents misconfiguration issues and avoids unexpected behavior during development and runtime.

Note :memo:

This is a structural fix in the configuration file—no logic or dependencies were changed.